### PR TITLE
feat: support C++ exceptions on wasm32-unknown-unknown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+### macOS ###
+.DS_Store
+
 ### C++ ###
 compile_commands.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,27 @@ cmake_minimum_required(VERSION 3.21)
 # Set the CMake toolchain file for cross-compilation
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/clang_toolchain.cmake" CACHE PATH "Path to the CMake's toolchain file")
 
-project(Wasm32UnknownUnknownLibCXX VERSION 0.1.2 LANGUAGES C CXX ASM)
+project(Wasm32UnknownUnknownLibCXX VERSION 0.1.3 LANGUAGES C CXX ASM)
 
-set(LIBCXX_ENABLE_EXCEPTIONS OFF CACHE BOOL "" FORCE)
-set(LIBCXXABI_ENABLE_EXCEPTIONS OFF CACHE BOOL "" FORCE)
+set(LIBCXX_ENABLE_EXCEPTIONS ON CACHE BOOL "" FORCE)
+set(LIBCXXABI_ENABLE_EXCEPTIONS ON CACHE BOOL "" FORCE)
+
+# Compile libcxx/libcxxabi/libunwind with native wasm exception handling so
+# the runtime support symbols (__cxa_*, __wasm_lpad_context,
+# _Unwind_CallPersonality) are emitted for the wasm EH ABI rather than the
+# Itanium/__cxa_throw shim.
+#
+# Also define __USING_WASM_EXCEPTIONS__ explicitly: in clang 22 the predefined
+# macro was renamed to __WASM_EXCEPTIONS__, but the libcxxabi 18 / libunwind 18
+# source still uses the older name to gate the wasm EH paths (e.g. it's what
+# spells out __gxx_personality_wasm0 instead of __gxx_personality_v0). Without
+# the define, libcxxabi compiles to an Itanium-only build and the wasm
+# personality stays absent.
+# `-mllvm -wasm-use-legacy-eh=false` opts into the standardized try_table /
+# exnref opcodes. Without it clang defaults to the legacy try / catch ops and
+# the wasm engine refuses to load modules that mix the two encodings.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fwasm-exceptions -D__USING_WASM_EXCEPTIONS__=1 -mllvm -wasm-use-legacy-eh=false")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fwasm-exceptions -D__USING_WASM_EXCEPTIONS__=1 -mllvm -wasm-use-legacy-eh=false")
 
 # Set C++ and C standards
 set(CMAKE_CXX_STANDARD 14)
@@ -127,14 +144,23 @@ install(DIRECTORY "${BUILD_INCLUDE_DIR}/"
 )
 
 # Fetch LLVM project
+# 19.1.7 is the minimum that builds cleanly along the wasm EH path. Its libc++
+# has complete C++20 ranges and its libc++abi/libunwind use consistent function
+# signatures. LLVM 18 mismatches the __cxa_init_primary_exception and
+# __cxa_throw destructor signatures when __USING_WASM_EXCEPTIONS__ is set.
 FetchContent_Declare(
     LLVMProject
-    URL https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/llvm-project-14.0.0.src.tar.xz
-    URL_HASH SHA256=35ce9edbc8f774fe07c8f4acdf89ec8ac695c8016c165dd86b8d10e7cba07e23
+    URL https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/llvm-project-19.1.7.src.tar.xz
+    URL_HASH SHA256=82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(LLVMProject)
 set(LLVM_PROJECT_SOURCE_DIR ${llvmproject_SOURCE_DIR})
+
+# Make LLVM's cmake helper modules (AddLLVM and friends) available to the
+# compiler-rt / libcxx / libcxxabi / libunwind subprojects when we build them
+# via add_subdirectory instead of the full LLVM_ENABLE_RUNTIMES dance.
+list(APPEND CMAKE_MODULE_PATH "${LLVM_PROJECT_SOURCE_DIR}/llvm/cmake/modules")
 
 # Build and install compiler-rt
 set(COMPILER_RT_BAREMETAL_BUILD ON CACHE BOOL "" FORCE)
@@ -154,7 +180,8 @@ install(FILES ${LLVM_PROJECT_SOURCE_DIR}/compiler-rt/LICENSE.TXT
 # Build and install libc++
 set(LIBCXX_ENABLE_STATIC_ABI_LIBRARY OFF CACHE BOOL "" FORCE)
 set(LIBCXX_ENABLE_SHARED OFF CACHE BOOL "" FORCE)
-set(LIBCXX_ENABLE_FILESYSTEM OFF CACHE BOOL "" FORCE)
+# Keep filesystem enabled. In libcxx 18+, disabling LIBCXX_ENABLE_FILESYSTEM
+# also strips std::basic_filebuf, which downstream code using <fstream> needs.
 set(LIBCXX_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
 set(LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)
 set(LIBCXX_INCLUDE_DOCS OFF CACHE BOOL "" FORCE)
@@ -167,14 +194,57 @@ install(FILES ${LLVM_PROJECT_SOURCE_DIR}/libcxx/LICENSE.TXT
     DESTINATION licenses/libcxx
 )
 
+# Build only Unwind-wasm.c from libunwind, which provides the runtime symbols
+# (__wasm_lpad_context, _Unwind_CallPersonality, __gxx_personality_wasm0)
+# emitted by -fwasm-exceptions. The rest of libunwind is the arch-generic
+# stack walker, whose __libunwind_config.h has no wasm32 case, so the full
+# add_subdirectory path fails to compile. Unwind-wasm.c needs none of it.
+add_library(unwind STATIC
+    ${LLVM_PROJECT_SOURCE_DIR}/libunwind/src/Unwind-wasm.c
+)
+target_compile_definitions(unwind PRIVATE
+    # Define away the _LIBUNWIND_TRACE_API logging macros so the build does not
+    # reference the unprovided logAPIs/logUnwinding/logDWARF debug symbols.
+    NDEBUG
+    _LIBUNWIND_IS_BAREMETAL=1
+    # -fwasm-exceptions sets __USING_WASM_EXCEPTIONS__ only on C++ TUs; for
+    # the C source we define it manually so the wasm EH personality code
+    # inside Unwind-wasm.c is included.
+    __USING_WASM_EXCEPTIONS__=1
+    # libunwind's config.h falls back to __declspec(dllexport) on non-ELF /
+    # non-MACH / non-AIX. wasm isn't any of those; hiding symbols turns the
+    # export macro into a no-op, which is what we want for static linking.
+    _LIBUNWIND_HIDE_SYMBOLS=1
+)
+target_compile_options(unwind PRIVATE -fwasm-exceptions)
+target_include_directories(unwind PRIVATE
+    ${LLVM_PROJECT_SOURCE_DIR}/libunwind/include
+    ${LLVM_PROJECT_SOURCE_DIR}/libunwind/src
+)
+
+install(TARGETS unwind
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)
+install(FILES ${LLVM_PROJECT_SOURCE_DIR}/libunwind/include/unwind.h
+    DESTINATION include
+)
+install(FILES ${LLVM_PROJECT_SOURCE_DIR}/libunwind/LICENSE.TXT
+    DESTINATION licenses/libunwind
+)
+
 # Build and install libc++abi
 set(LIBCXXABI_ENABLE_SHARED OFF CACHE BOOL "" FORCE)
 set(LIBCXXABI_ENABLE_THREADS OFF CACHE BOOL "" FORCE)
 set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "" FORCE)
+# Defaults to ON in libcxxabi 18; we build libunwind separately via
+# add_subdirectory above and rely on downstream to link it explicitly, so the
+# LLVM_ENABLE_RUNTIMES-aware integration is unnecessary.
+set(LIBCXXABI_USE_LLVM_UNWINDER OFF CACHE BOOL "" FORCE)
+set(LIBCXXABI_LIBUNWIND_INCLUDES "${LLVM_PROJECT_SOURCE_DIR}/libunwind/include" CACHE PATH "" FORCE)
 set(LIBCXXABI_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
 set(LIBCXXABI_BAREMETAL ON CACHE BOOL "" FORCE)
 set(LIBCXXABI_SILENT_TERMINATE ON CACHE BOOL "" FORCE)
-set(LIBCXXABI_NON_DEMANGLING_TERMINATE ON CACHE BOOL "" FORCE)
 
 add_subdirectory(${LLVM_PROJECT_SOURCE_DIR}/libcxxabi libcxxabi)
 install(FILES ${LLVM_PROJECT_SOURCE_DIR}/libcxxabi/LICENSE.TXT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,17 @@ install(CODE "
     file(WRITE \"${CMAKE_INSTALL_PREFIX}/include/c++/v1/cmath\" \"\${CMATH_CONTENT_PATCHED}\")
 ")
 
+# Define the __cpp_exception tag that -fwasm-exceptions imports from `env`.
+# wasm-ld merges this module-local definition with those imports, so links need
+# no post-processing to drop the `env` import. Installed as libcppexception.a so
+# env.sh can pull it with -lstatic=cppexception.
+add_library(cppexception STATIC "${CMAKE_CURRENT_SOURCE_DIR}/cpp_exception_tag.s")
+set_target_properties(cppexception PROPERTIES LINKER_LANGUAGE C)
+install(TARGETS cppexception
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)
+
 # Install the environment script
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/env.sh" DESTINATION .)
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/env.bat" DESTINATION .)

--- a/clang_toolchain.cmake
+++ b/clang_toolchain.cmake
@@ -2,18 +2,25 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set(CMAKE_SYSTEM_NAME Generic)
 
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
-set(CMAKE_ASM_COMPILER clang)
-set(CMAKE_LINKER lld)
+# Allow LLVM_TOOLCHAIN_PREFIX to point at a custom LLVM install (e.g.
+# /opt/homebrew/opt/llvm/bin/ on macOS, where Apple's stock clang has no
+# wasm32 target).
+if(NOT DEFINED LLVM_TOOLCHAIN_PREFIX)
+    set(LLVM_TOOLCHAIN_PREFIX "" CACHE STRING "Prefix path for clang/llvm-* tools")
+endif()
 
-set(CMAKE_AR llvm-ar)
-set(CMAKE_OBJCOPY llvm-objcopy)
-set(CMAKE_OBJCOPY_BIN llvm-objcopy)
-set(CMAKE_RANLIB llvm-ranlib)
-set(CMAKE_STRIP llvm-strip)
-set(CMAKE_SIZE_BIN llvm-size)
-set(CMAKE_NM llvm-nm)
+set(CMAKE_C_COMPILER ${LLVM_TOOLCHAIN_PREFIX}clang)
+set(CMAKE_CXX_COMPILER ${LLVM_TOOLCHAIN_PREFIX}clang++)
+set(CMAKE_ASM_COMPILER ${LLVM_TOOLCHAIN_PREFIX}clang)
+set(CMAKE_LINKER ${LLVM_TOOLCHAIN_PREFIX}lld)
+
+set(CMAKE_AR ${LLVM_TOOLCHAIN_PREFIX}llvm-ar)
+set(CMAKE_OBJCOPY ${LLVM_TOOLCHAIN_PREFIX}llvm-objcopy)
+set(CMAKE_OBJCOPY_BIN ${LLVM_TOOLCHAIN_PREFIX}llvm-objcopy)
+set(CMAKE_RANLIB ${LLVM_TOOLCHAIN_PREFIX}llvm-ranlib)
+set(CMAKE_STRIP ${LLVM_TOOLCHAIN_PREFIX}llvm-strip)
+set(CMAKE_SIZE_BIN ${LLVM_TOOLCHAIN_PREFIX}llvm-size)
+set(CMAKE_NM ${LLVM_TOOLCHAIN_PREFIX}llvm-nm)
 
 set(CMAKE_C_COMPILER_TARGET wasm32-unknown-unknown)
 set(CMAKE_CXX_COMPILER_TARGET wasm32-unknown-unknown)

--- a/cpp_exception_tag.s
+++ b/cpp_exception_tag.s
@@ -1,0 +1,8 @@
+# Defines the __cpp_exception tag that clang -fwasm-exceptions emits as an
+# undefined `env` import in every EH object. wasm-ld never synthesizes it on
+# bare wasm32-unknown-unknown. This module-local definition gets merged with
+# those imports at link time, so the module links and instantiates with no
+# `env` import and no post-link rewrite.
+	.tagtype	__cpp_exception i32
+	.globl	__cpp_exception
+__cpp_exception:

--- a/env.sh
+++ b/env.sh
@@ -17,7 +17,10 @@ else
     fi
 fi
 
-export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C link-arg=-L$WASM32_UNKNOWN_UNKNOWN_STDLIB/lib/ -L $WASM32_UNKNOWN_UNKNOWN_STDLIB/lib/ -lstatic=c -lstatic=c++abi -lstatic=unwind --Z wasm_c_abi=spec"
+# libcppexception.a defines the env.__cpp_exception tag that -fwasm-exceptions
+# emits and wasm-ld never supplies on bare wasm32-unknown-unknown. wasm-ld
+# merges it with the imports so links need no post-processing.
+export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C link-arg=-L$WASM32_UNKNOWN_UNKNOWN_STDLIB/lib/ -L $WASM32_UNKNOWN_UNKNOWN_STDLIB/lib/ -lstatic=c -lstatic=c++abi -lstatic=unwind -lstatic=cppexception --Z wasm_c_abi=spec"
 export CFLAGS_wasm32_unknown_unknown="--sysroot=$WASM32_UNKNOWN_UNKNOWN_STDLIB -D__OpenBSD__ -D__WASM32_UNKNOWN_UNKNOWN__"
 export CXXFLAGS_wasm32_unknown_unknown="$CFLAGS_wasm32_unknown_unknown -fwasm-exceptions -mllvm -wasm-use-legacy-eh=false"
 export BINDGEN_EXTRA_CLANG_ARGS_wasm32_unknown_unknown="-fvisibility=default"

--- a/env.sh
+++ b/env.sh
@@ -17,7 +17,7 @@ else
     fi
 fi
 
-export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C link-arg=-L$WASM32_UNKNOWN_UNKNOWN_STDLIB/lib/ -L $WASM32_UNKNOWN_UNKNOWN_STDLIB/lib/ -lstatic=c -lstatic=c++abi --Z wasm_c_abi=spec"
+export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C link-arg=-L$WASM32_UNKNOWN_UNKNOWN_STDLIB/lib/ -L $WASM32_UNKNOWN_UNKNOWN_STDLIB/lib/ -lstatic=c -lstatic=c++abi -lstatic=unwind --Z wasm_c_abi=spec"
 export CFLAGS_wasm32_unknown_unknown="--sysroot=$WASM32_UNKNOWN_UNKNOWN_STDLIB -D__OpenBSD__ -D__WASM32_UNKNOWN_UNKNOWN__"
-export CXXFLAGS_wasm32_unknown_unknown="$CFLAGS_wasm32_unknown_unknown -fexceptions"
+export CXXFLAGS_wasm32_unknown_unknown="$CFLAGS_wasm32_unknown_unknown -fwasm-exceptions -mllvm -wasm-use-legacy-eh=false"
 export BINDGEN_EXTRA_CLANG_ARGS_wasm32_unknown_unknown="-fvisibility=default"

--- a/include/threads.h
+++ b/include/threads.h
@@ -1,0 +1,11 @@
+// Minimal C11 <threads.h> stub for wasm32-unknown-unknown (single-threaded).
+// Only provides the `thread_local` macro, which is what libunwind's
+// Unwind-wasm.c actually needs. Real thread support is intentionally absent.
+#ifndef _WASM32_UNKNOWN_UNKNOWN_LIBCXX_THREADS_H
+#define _WASM32_UNKNOWN_UNKNOWN_LIBCXX_THREADS_H
+
+#ifndef thread_local
+#define thread_local _Thread_local
+#endif
+
+#endif


### PR DESCRIPTION
Builds libc++, libc++abi, and libunwind with `-fwasm-exceptions` (LLVM bumped to 19.1.7 for consistent wasm EH signatures), so C++ code can throw and catch instead of aborting. `libcppexception.a` supplies the `__cpp_exception` tag that clang imports but wasm-ld never defines on standalone wasm. `LLVM_TOOLCHAIN_PREFIX` allows a non-default LLVM (e.g. Homebrew) to be used.